### PR TITLE
Keep dependencies up-to-date with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: maven
+    directory: /examples/maven/deepl-test-app
+    schedule:
+      interval: weekly


### PR DESCRIPTION
The following Dependabot configuration should track dependencies in both main and example projects (fixes #9). 