### PR TITLE
Migrate deepl-test-app to Junit 5

### DIFF
--- a/examples/maven/deepl-test-app/pom.xml
+++ b/examples/maven/deepl-test-app/pom.xml
@@ -15,9 +15,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -34,12 +34,13 @@
       <build>
         <plugins>
           <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <version>3.1.2</version>
-              <configuration>
-                <excludedGroups>com.deepl.deepltestapp.annotation.IntegrationTest</excludedGroups>
-              </configuration>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.1.2</version>
+            <configuration>
+              <excludes>
+                <exclude>**/*IntegrationTest.java</exclude>
+              </excludes>
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -47,23 +48,17 @@
     <profile>
       <id>runIntegrationTests</id>
       <build>
-          <plugins>
-              <plugin>
-                  <artifactId>maven-surefire-plugin</artifactId>
-                  <version>3.1.2</version>
-                  <executions>
-                      <execution>
-                          <phase>integration-test</phase>
-                          <configuration>
-                            <includes>
-                              <include>**/*</include>
-                            </includes>
-                            <groups>com.deepl.deepltestapp.annotation.IntegrationTest</groups>
-                          </configuration>
-                      </execution>
-                  </executions>
-              </plugin>
-          </plugins>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.1.2</version>
+            <executions>
+              <execution>
+                <phase>integration-test</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>

--- a/examples/maven/deepl-test-app/src/main/java/com/deepl/deepltestapp/annotation/IntegrationTest.java
+++ b/examples/maven/deepl-test-app/src/main/java/com/deepl/deepltestapp/annotation/IntegrationTest.java
@@ -1,9 +1,0 @@
-// Copyright 2023 DeepL SE (https://www.deepl.com)
-// Use of this source code is governed by an MIT
-// license that can be found in the LICENSE file.
-package com.deepl.deepltestapp.annotation;
-
-/**
- * Marks tests as Integration tests, used for DeepLs internal CI pipeline.
- */
-public interface IntegrationTest {}

--- a/examples/maven/deepl-test-app/src/test/java/com/deepl/deepltestapp/DeepLIntegrationTest.java
+++ b/examples/maven/deepl-test-app/src/test/java/com/deepl/deepltestapp/DeepLIntegrationTest.java
@@ -4,37 +4,26 @@
 package com.deepl.deepltestapp;
 
 import com.deepl.api.*;
-import com.deepl.deepltestapp.*;
-import com.deepl.deepltestapp.annotation.IntegrationTest;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.junit.Assert.*;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Internal DeepL Integration Test
  */
-@Category(IntegrationTest.class)
-public class DeepLIntegrationTest extends TestCase {
-    public DeepLIntegrationTest(String testName) {
-        super(testName);
-    }
-
-    public static Test suite() {
-        return new TestSuite(DeepLIntegrationTest.class);
-    }
+public class DeepLIntegrationTest {
 
     /**
      * Runs the hello world example. Requires a DeepL auth key via the DEEPL_AUTH_KEY
      * environment variable.
      */
-    public void testApp() throws InterruptedException, DeepLException {
+    @Test
+    void testApp() throws InterruptedException, DeepLException {
         String result = App.translateHelloWorld();
         String[] wordsToCheck = {"Hello", "World"};
         for (String wordToCheck : wordsToCheck) {
-            assertFalse(String.format("Expected translation to no longer contain the english %s, received %s", 
-                wordToCheck, result), result.contains(wordToCheck)
+            assertFalse(result.contains(wordToCheck),
+                    String.format("Expected translation to no longer contain the english %s, received %s", wordToCheck, result)
             );
         }
     }


### PR DESCRIPTION
Ahoy, @JanEbbing! 👋

The integration test in the sample project is based on the older JUnit 4. This PR migrates it to JUnit 5.10.0 to be in sync with the main project. I think the Maven profiles `buildProject` / `runIntegrationTests` can also be eliminated in favor of the more universal `mvn package -DskipTests`. Look forward to hearing what you think.