### PR TITLE
Remove alpha label from context parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ a `TextTranslationOptions`, with the following setters:
     - `setGlossaryId()` is also available for backward-compatibility, accepting
       a string containing the glossary ID.
 - `setContext()`: specifies additional context to influence translations, that is not
-  translated itself. Note this is an **alpha feature**: it may be deprecated at
-  any time, or incur charges if it becomes generally available.
+  translated itself. Characters in the `context` parameter are not counted toward billing.  
   See the [API documentation][api-docs-context-param] for more information and
   example usage.
 - `setTagHandling()`: type of tags to parse before translation, options are

--- a/deepl-java/src/main/java/com/deepl/api/TextTranslationOptions.java
+++ b/deepl-java/src/main/java/com/deepl/api/TextTranslationOptions.java
@@ -65,9 +65,9 @@ public class TextTranslationOptions {
   }
 
   /**
-   * Specifies additional context to influence translations, that is not translated itself. Note:
-   * this is an alpha feature: it may be deprecated at any time, or incur charges if it becomes
-   * generally available. See the API documentation for more information and example usage.
+   * Specifies additional context to influence translations, that is not translated itself.
+   * Characters in the `context` parameter are not counted toward billing.
+   * See the API documentation for more information and example usage.
    */
   public TextTranslationOptions setContext(String context) {
     this.context = context;


### PR DESCRIPTION
The `context` parameter is no longer an alpha feature and is generally available. This PR updates the README to reflect this change.