### PR TITLE
fix: issue#44 integer overflow in usage request

### DIFF
--- a/deepl-java/src/main/java/com/deepl/api/parsing/Parser.java
+++ b/deepl-java/src/main/java/com/deepl/api/parsing/Parser.java
@@ -76,6 +76,11 @@ public class Parser {
     return jsonObject.get(parameterName).getAsInt();
   }
 
+  static @Nullable Long getAsLongOrNull(JsonObject jsonObject, String parameterName) {
+    if (!jsonObject.has(parameterName)) return null;
+    return jsonObject.get(parameterName).getAsLong();
+  }
+
   static @Nullable String getAsStringOrNull(JsonObject jsonObject, String parameterName) {
     if (!jsonObject.has(parameterName)) return null;
     return jsonObject.get(parameterName).getAsString();

--- a/deepl-java/src/main/java/com/deepl/api/parsing/UsageDeserializer.java
+++ b/deepl-java/src/main/java/com/deepl/api/parsing/UsageDeserializer.java
@@ -25,8 +25,8 @@ class UsageDeserializer implements JsonDeserializer<Usage> {
   }
 
   public static @Nullable Usage.Detail createDetail(JsonObject jsonObject, String prefix) {
-    Integer count = Parser.getAsIntOrNull(jsonObject, prefix + "count");
-    Integer limit = Parser.getAsIntOrNull(jsonObject, prefix + "limit");
+    Long count = Parser.getAsLongOrNull(jsonObject, prefix + "count");
+    Long limit = Parser.getAsLongOrNull(jsonObject, prefix + "limit");
     if (count == null || limit == null) return null;
     return new Usage.Detail(count, limit);
   }


### PR DESCRIPTION
 - `Usage.Detail::count` and `Usage.Detail::limit` were declared as `long` but parsed as `int`.
 - This seems to be caused by a176b6de, where the type was changed from `int` to `long` without adjusting the parsing.
 - This caused an integer overflow, resulting in a negative value when e.g. the character limit exceeded `Integer::MAX_VAlUE`.