### PR TITLE
feat: add override for ``Translator.translateText`` to get rid of null parsing for ``sourceLang`` to auto-detect

### DIFF
--- a/deepl-java/src/main/java/com/deepl/api/Translator.java
+++ b/deepl-java/src/main/java/com/deepl/api/Translator.java
@@ -109,6 +109,20 @@ public class Translator {
   }
 
   /**
+   * Functions the same as {@link Translator#translateText(String, String, String,
+   * TextTranslationOptions)} but sourceLang is auto-detected.
+   */
+  public TextResult translateText(
+          String text,
+          String targetLang,
+          @Nullable TextTranslationOptions options)
+          throws InterruptedException, DeepLException {
+    ArrayList<String> texts = new ArrayList<>();
+    texts.add(text);
+    return translateText(texts, null, targetLang, options).get(0);
+  }
+
+  /**
    * Translate specified text from source language into target language.
    *
    * @param text Text to translate; must not be empty.

--- a/deepl-java/src/main/java/com/deepl/api/Translator.java
+++ b/deepl-java/src/main/java/com/deepl/api/Translator.java
@@ -171,6 +171,20 @@ public class Translator {
 
   /**
    * Functions the same as {@link Translator#translateText(String, String, String,
+   * TextTranslationOptions)} but accepts {@link Language} objects for target language and sourceLang is auto-detected.
+   *
+   * @see Translator#translateText(String, String, String, TextTranslationOptions)
+   */
+  public TextResult translateText(
+          String text,
+          Language targetLang,
+          @Nullable TextTranslationOptions options)
+          throws DeepLException, InterruptedException {
+    return translateText(text, null, targetLang.getCode(), options);
+  }
+
+  /**
+   * Functions the same as {@link Translator#translateText(String, String, String,
    * TextTranslationOptions)} but accepts {@link Language} objects for source and target languages.
    *
    * @see Translator#translateText(String, String, String, TextTranslationOptions)


### PR DESCRIPTION
- added two method overrides
- one for Languages as ``String`` and another for ``Language``
- overrides got no ``sourceLang`` as parameter and therefore have auto-detect (parse ``null``)