### PR TITLE
cleanup: remove createTranslator methods in BaseTest

### DIFF
--- a/deepl-java/src/test/java/com/deepl/api/GlossaryTest.java
+++ b/deepl-java/src/test/java/com/deepl/api/GlossaryTest.java
@@ -35,23 +35,22 @@ public class GlossaryTest extends TestBase {
 
   @Test
   void testGlossaryCreate() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       GlossaryEntries entries = new GlossaryEntries(Collections.singletonMap("Hello", "Hallo"));
       System.out.println(entries);
       for (Map.Entry<String, String> entry : entries.entrySet()) {
         System.out.println(entry.getKey() + ":" + entry.getValue());
       }
       String glossaryName = cleanup.getGlossaryName();
-      GlossaryInfo glossary =
-          translator.createGlossary(glossaryName, sourceLang, targetLang, entries);
+      GlossaryInfo glossary = client.createGlossary(glossaryName, sourceLang, targetLang, entries);
 
       Assertions.assertEquals(glossaryName, glossary.getName());
       Assertions.assertEquals(sourceLang, glossary.getSourceLang());
       Assertions.assertEquals(targetLang, glossary.getTargetLang());
       Assertions.assertEquals(1, glossary.getEntryCount());
 
-      GlossaryInfo getResult = translator.getGlossary(glossary.getGlossaryId());
+      GlossaryInfo getResult = client.getGlossary(glossary.getGlossaryId());
       Assertions.assertEquals(getResult.getName(), glossary.getName());
       Assertions.assertEquals(getResult.getSourceLang(), glossary.getSourceLang());
       Assertions.assertEquals(getResult.getTargetLang(), glossary.getTargetLang());
@@ -62,8 +61,8 @@ public class GlossaryTest extends TestBase {
 
   @Test
   void testGlossaryCreateLarge() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
 
       Map<String, String> entryPairs = new HashMap<>();
@@ -72,8 +71,7 @@ public class GlossaryTest extends TestBase {
       }
       GlossaryEntries entries = new GlossaryEntries(entryPairs);
       Assertions.assertTrue(entries.toTsv().length() > 100000);
-      GlossaryInfo glossary =
-          translator.createGlossary(glossaryName, sourceLang, targetLang, entries);
+      GlossaryInfo glossary = client.createGlossary(glossaryName, sourceLang, targetLang, entries);
 
       Assertions.assertEquals(glossaryName, glossary.getName());
       Assertions.assertEquals(sourceLang, glossary.getSourceLang());
@@ -84,8 +82,8 @@ public class GlossaryTest extends TestBase {
 
   @Test
   void testGlossaryCreateCsv() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
       Map<String, String> expectedEntries = new HashMap<>();
       expectedEntries.put("sourceEntry1", "targetEntry1");
@@ -95,35 +93,34 @@ public class GlossaryTest extends TestBase {
           "sourceEntry1,targetEntry1,en,de\n\"source\"\"Entry\",\"target,Entry\",en,de";
 
       GlossaryInfo glossary =
-          translator.createGlossaryFromCsv(glossaryName, sourceLang, targetLang, csvContent);
+          client.createGlossaryFromCsv(glossaryName, sourceLang, targetLang, csvContent);
 
-      GlossaryEntries entries = translator.getGlossaryEntries(glossary);
+      GlossaryEntries entries = client.getGlossaryEntries(glossary);
       Assertions.assertEquals(expectedEntries, entries);
     }
   }
 
   @Test
   void testGlossaryCreateInvalid() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
       Assertions.assertThrows(
-          Exception.class,
-          () -> translator.createGlossary("", sourceLang, targetLang, testEntries));
+          Exception.class, () -> client.createGlossary("", sourceLang, targetLang, testEntries));
       Assertions.assertThrows(
-          Exception.class, () -> translator.createGlossary(glossaryName, "en", "xx", testEntries));
+          Exception.class, () -> client.createGlossary(glossaryName, "en", "xx", testEntries));
     }
   }
 
   @Test
   void testGlossaryGet() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
       GlossaryInfo createdGlossary =
-          translator.createGlossary(glossaryName, sourceLang, targetLang, testEntries);
+          client.createGlossary(glossaryName, sourceLang, targetLang, testEntries);
 
-      GlossaryInfo glossary = translator.getGlossary(createdGlossary.getGlossaryId());
+      GlossaryInfo glossary = client.getGlossary(createdGlossary.getGlossaryId());
       Assertions.assertEquals(createdGlossary.getGlossaryId(), glossary.getGlossaryId());
       Assertions.assertEquals(glossaryName, glossary.getName());
       Assertions.assertEquals(sourceLang, glossary.getSourceLang());
@@ -131,15 +128,15 @@ public class GlossaryTest extends TestBase {
       Assertions.assertEquals(createdGlossary.getCreationTime(), glossary.getCreationTime());
       Assertions.assertEquals(testEntries.size(), glossary.getEntryCount());
     }
-    Assertions.assertThrows(DeepLException.class, () -> translator.getGlossary(invalidGlossaryId));
+    Assertions.assertThrows(DeepLException.class, () -> client.getGlossary(invalidGlossaryId));
     Assertions.assertThrows(
-        GlossaryNotFoundException.class, () -> translator.getGlossary(nonexistentGlossaryId));
+        GlossaryNotFoundException.class, () -> client.getGlossary(nonexistentGlossaryId));
   }
 
   @Test
   void testGlossaryGetEntries() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
       GlossaryEntries entries = new GlossaryEntries();
       entries.put("Apple", "Apfel");
@@ -149,27 +146,25 @@ public class GlossaryTest extends TestBase {
       entries.put("\uD83E\uDEA8", "\uD83E\uDEB5");
 
       GlossaryInfo createdGlossary =
-          translator.createGlossary(glossaryName, sourceLang, targetLang, entries);
-      Assertions.assertEquals(entries, translator.getGlossaryEntries(createdGlossary));
-      Assertions.assertEquals(
-          entries, translator.getGlossaryEntries(createdGlossary.getGlossaryId()));
+          client.createGlossary(glossaryName, sourceLang, targetLang, entries);
+      Assertions.assertEquals(entries, client.getGlossaryEntries(createdGlossary));
+      Assertions.assertEquals(entries, client.getGlossaryEntries(createdGlossary.getGlossaryId()));
     }
 
     Assertions.assertThrows(
-        DeepLException.class, () -> translator.getGlossaryEntries(invalidGlossaryId));
+        DeepLException.class, () -> client.getGlossaryEntries(invalidGlossaryId));
     Assertions.assertThrows(
-        GlossaryNotFoundException.class,
-        () -> translator.getGlossaryEntries(nonexistentGlossaryId));
+        GlossaryNotFoundException.class, () -> client.getGlossaryEntries(nonexistentGlossaryId));
   }
 
   @Test
   void testGlossaryList() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
-      translator.createGlossary(glossaryName, sourceLang, targetLang, testEntries);
+      client.createGlossary(glossaryName, sourceLang, targetLang, testEntries);
 
-      List<GlossaryInfo> glossaries = translator.listGlossaries();
+      List<GlossaryInfo> glossaries = client.listGlossaries();
       Assertions.assertTrue(
           glossaries.stream()
               .anyMatch((glossaryInfo -> Objects.equals(glossaryInfo.getName(), glossaryName))));
@@ -178,27 +173,26 @@ public class GlossaryTest extends TestBase {
 
   @Test
   void testGlossaryDelete() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
       GlossaryInfo glossary =
-          translator.createGlossary(glossaryName, sourceLang, targetLang, testEntries);
+          client.createGlossary(glossaryName, sourceLang, targetLang, testEntries);
 
-      translator.deleteGlossary(glossary);
+      client.deleteGlossary(glossary);
       Assertions.assertThrows(
-          GlossaryNotFoundException.class, () -> translator.deleteGlossary(glossary));
+          GlossaryNotFoundException.class, () -> client.deleteGlossary(glossary));
 
+      Assertions.assertThrows(DeepLException.class, () -> client.deleteGlossary(invalidGlossaryId));
       Assertions.assertThrows(
-          DeepLException.class, () -> translator.deleteGlossary(invalidGlossaryId));
-      Assertions.assertThrows(
-          GlossaryNotFoundException.class, () -> translator.deleteGlossary(nonexistentGlossaryId));
+          GlossaryNotFoundException.class, () -> client.deleteGlossary(nonexistentGlossaryId));
     }
   }
 
   @Test
   void testGlossaryTranslateTextSentence() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
       GlossaryEntries entries =
           new GlossaryEntries() {
@@ -209,11 +203,10 @@ public class GlossaryTest extends TestBase {
           };
       String inputText = "The artist was awarded a prize.";
 
-      GlossaryInfo glossary =
-          translator.createGlossary(glossaryName, sourceLang, targetLang, entries);
+      GlossaryInfo glossary = client.createGlossary(glossaryName, sourceLang, targetLang, entries);
 
       TextResult result =
-          translator.translateText(
+          client.translateText(
               inputText,
               sourceLang,
               targetLang,
@@ -225,7 +218,7 @@ public class GlossaryTest extends TestBase {
 
       // It is also possible to specify GlossaryInfo
       result =
-          translator.translateText(
+          client.translateText(
               inputText,
               sourceLang,
               targetLang,
@@ -239,9 +232,9 @@ public class GlossaryTest extends TestBase {
 
   @Test
   void testGlossaryTranslateTextBasic() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanupEnDe = new GlossaryCleanupUtility(translator, "EnDe");
-        GlossaryCleanupUtility cleanupDeEn = new GlossaryCleanupUtility(translator, "DeEn")) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanupEnDe = new GlossaryCleanupUtility(client, "EnDe");
+        GlossaryCleanupUtility cleanupDeEn = new GlossaryCleanupUtility(client, "DeEn")) {
       String glossaryNameEnDe = cleanupEnDe.getGlossaryName();
       String glossaryNameDeEn = cleanupDeEn.getGlossaryName();
       List<String> textsEn =
@@ -266,18 +259,18 @@ public class GlossaryTest extends TestBase {
       }
 
       GlossaryInfo glossaryEnDe =
-          translator.createGlossary(glossaryNameEnDe, "en", "de", glossaryEntriesEnDe);
+          client.createGlossary(glossaryNameEnDe, "en", "de", glossaryEntriesEnDe);
       GlossaryInfo glossaryDeEn =
-          translator.createGlossary(glossaryNameDeEn, "de", "en", glossaryEntriesDeEn);
+          client.createGlossary(glossaryNameDeEn, "de", "en", glossaryEntriesDeEn);
 
       List<TextResult> result =
-          translator.translateText(
+          client.translateText(
               textsEn, "en", "de", new TextTranslationOptions().setGlossary(glossaryEnDe));
       Assertions.assertArrayEquals(
           textsDe.toArray(), result.stream().map(TextResult::getText).toArray());
 
       result =
-          translator.translateText(
+          client.translateText(
               textsDe,
               "de",
               "en-US",
@@ -289,8 +282,8 @@ public class GlossaryTest extends TestBase {
 
   @Test
   void testGlossaryTranslateDocument() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(translator)) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanup = new GlossaryCleanupUtility(client)) {
       String glossaryName = cleanup.getGlossaryName();
       File inputFile = createInputFile("artist\nprize");
       File outputFile = createOutputFile();
@@ -303,10 +296,9 @@ public class GlossaryTest extends TestBase {
             }
           };
 
-      GlossaryInfo glossary =
-          translator.createGlossary(glossaryName, sourceLang, targetLang, entries);
+      GlossaryInfo glossary = client.createGlossary(glossaryName, sourceLang, targetLang, entries);
 
-      translator.translateDocument(
+      client.translateDocument(
           inputFile,
           outputFile,
           sourceLang,
@@ -315,7 +307,7 @@ public class GlossaryTest extends TestBase {
       Assertions.assertEquals(expectedOutput, readFromFile(outputFile));
       boolean ignored = outputFile.delete();
 
-      translator.translateDocument(
+      client.translateDocument(
           inputFile,
           outputFile,
           sourceLang,
@@ -327,22 +319,20 @@ public class GlossaryTest extends TestBase {
 
   @Test
   void testGlossaryTranslateTextInvalid() throws Exception {
-    Translator translator = createTranslator();
-    try (GlossaryCleanupUtility cleanupEnDe = new GlossaryCleanupUtility(translator, "EnDe");
-        GlossaryCleanupUtility cleanupDeEn = new GlossaryCleanupUtility(translator, "DeEn")) {
+    DeepLClient client = createDeepLClient();
+    try (GlossaryCleanupUtility cleanupEnDe = new GlossaryCleanupUtility(client, "EnDe");
+        GlossaryCleanupUtility cleanupDeEn = new GlossaryCleanupUtility(client, "DeEn")) {
       String glossaryNameEnDe = cleanupEnDe.getGlossaryName();
       String glossaryNameDeEn = cleanupDeEn.getGlossaryName();
 
-      GlossaryInfo glossaryEnDe =
-          translator.createGlossary(glossaryNameEnDe, "en", "de", testEntries);
-      GlossaryInfo glossaryDeEn =
-          translator.createGlossary(glossaryNameDeEn, "de", "en", testEntries);
+      GlossaryInfo glossaryEnDe = client.createGlossary(glossaryNameEnDe, "en", "de", testEntries);
+      GlossaryInfo glossaryDeEn = client.createGlossary(glossaryNameDeEn, "de", "en", testEntries);
 
       IllegalArgumentException exception =
           Assertions.assertThrows(
               IllegalArgumentException.class,
               () ->
-                  translator.translateText(
+                  client.translateText(
                       "test", null, "de", new TextTranslationOptions().setGlossary(glossaryEnDe)));
       Assertions.assertTrue(exception.getMessage().contains("sourceLang is required"));
 
@@ -350,7 +340,7 @@ public class GlossaryTest extends TestBase {
           Assertions.assertThrows(
               IllegalArgumentException.class,
               () ->
-                  translator.translateText(
+                  client.translateText(
                       "test", "de", "en", new TextTranslationOptions().setGlossary(glossaryDeEn)));
       Assertions.assertTrue(exception.getMessage().contains("targetLang=\"en\" is not allowed"));
     }

--- a/deepl-java/src/test/java/com/deepl/api/TestBase.java
+++ b/deepl-java/src/test/java/com/deepl/api/TestBase.java
@@ -90,41 +90,6 @@ public class TestBase {
     tempDir = createTempDir();
   }
 
-  // TODO: Delete `createTranslator` methods, replace with `createDeepLClient`
-  protected Translator createTranslator() {
-    SessionOptions sessionOptions = new SessionOptions();
-    return createTranslator(sessionOptions);
-  }
-
-  protected Translator createTranslator(SessionOptions sessionOptions) {
-    TranslatorOptions translatorOptions = new TranslatorOptions();
-    return createTranslator(sessionOptions, translatorOptions);
-  }
-
-  protected Translator createTranslator(
-      SessionOptions sessionOptions, TranslatorOptions translatorOptions) {
-    Map<String, String> headers = sessionOptions.createSessionHeaders();
-
-    if (translatorOptions.getServerUrl() == null) {
-      translatorOptions.setServerUrl(serverUrl);
-    }
-
-    if (translatorOptions.getHeaders() != null) {
-      headers.putAll(translatorOptions.getHeaders());
-    }
-    translatorOptions.setHeaders(headers);
-
-    String authKey = sessionOptions.randomAuthKey ? UUID.randomUUID().toString() : TestBase.authKey;
-
-    try {
-      return new Translator(authKey, translatorOptions);
-    } catch (IllegalArgumentException e) {
-      e.printStackTrace();
-      System.exit(1);
-      return null;
-    }
-  }
-
   protected DeepLClient createDeepLClient() {
     SessionOptions sessionOptions = new SessionOptions();
     return createDeepLClient(sessionOptions);

--- a/deepl-java/src/test/java/com/deepl/api/TranslateTextTest.java
+++ b/deepl-java/src/test/java/com/deepl/api/TranslateTextTest.java
@@ -13,8 +13,8 @@ public class TranslateTextTest extends TestBase {
 
   @Test
   void testSingleText() throws DeepLException, InterruptedException {
-    Translator translator = createTranslator();
-    TextResult result = translator.translateText(exampleText.get("en"), null, LanguageCode.German);
+    DeepLClient client = createDeepLClient();
+    TextResult result = client.translateText(exampleText.get("en"), null, LanguageCode.German);
     Assertions.assertEquals(exampleText.get("de"), result.getText());
     Assertions.assertEquals("en", result.getDetectedSourceLanguage());
     Assertions.assertEquals(exampleText.get("en").length(), result.getBilledCharacters());
@@ -22,11 +22,11 @@ public class TranslateTextTest extends TestBase {
 
   @Test
   void testTextArray() throws DeepLException, InterruptedException {
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     List<String> texts = new ArrayList<>();
     texts.add(exampleText.get("fr"));
     texts.add(exampleText.get("en"));
-    List<TextResult> result = translator.translateText(texts, null, LanguageCode.German);
+    List<TextResult> result = client.translateText(texts, null, LanguageCode.German);
     Assertions.assertEquals(exampleText.get("de"), result.get(0).getText());
     Assertions.assertEquals(exampleText.get("de"), result.get(1).getText());
   }
@@ -39,12 +39,12 @@ public class TranslateTextTest extends TestBase {
           Assertions.assertEquals("en", result.getDetectedSourceLanguage());
         };
 
-    Translator translator = createTranslator();
-    checkResult.accept(translator.translateText(exampleText.get("en"), null, "DE"));
-    checkResult.accept(translator.translateText(exampleText.get("en"), "En", "DE"));
-    checkResult.accept(translator.translateText(exampleText.get("en"), "en", "DE"));
+    DeepLClient client = createDeepLClient();
+    checkResult.accept(client.translateText(exampleText.get("en"), null, "DE"));
+    checkResult.accept(client.translateText(exampleText.get("en"), "En", "DE"));
+    checkResult.accept(client.translateText(exampleText.get("en"), "en", "DE"));
 
-    List<Language> sourceLanguages = translator.getSourceLanguages();
+    List<Language> sourceLanguages = client.getSourceLanguages();
     Language sourceLanguageEn =
         sourceLanguages.stream()
             .filter((language -> Objects.equals(language.getCode(), "en")))
@@ -58,7 +58,7 @@ public class TranslateTextTest extends TestBase {
     Assertions.assertNotNull(sourceLanguageEn);
     Assertions.assertNotNull(sourceLanguageDe);
     checkResult.accept(
-        translator.translateText(exampleText.get("en"), sourceLanguageEn, sourceLanguageDe));
+        client.translateText(exampleText.get("en"), sourceLanguageEn, sourceLanguageDe));
   }
 
   @Test
@@ -69,42 +69,42 @@ public class TranslateTextTest extends TestBase {
           Assertions.assertEquals("en", result.getDetectedSourceLanguage());
         };
 
-    Translator translator = createTranslator();
-    checkResult.accept(translator.translateText(exampleText.get("en"), null, "De"));
-    checkResult.accept(translator.translateText(exampleText.get("en"), null, "de"));
-    checkResult.accept(translator.translateText(exampleText.get("en"), null, "DE"));
+    DeepLClient client = createDeepLClient();
+    checkResult.accept(client.translateText(exampleText.get("en"), null, "De"));
+    checkResult.accept(client.translateText(exampleText.get("en"), null, "de"));
+    checkResult.accept(client.translateText(exampleText.get("en"), null, "DE"));
 
-    List<Language> targetLanguages = translator.getTargetLanguages();
+    List<Language> targetLanguages = client.getTargetLanguages();
     Language targetLanguageDe =
         targetLanguages.stream()
             .filter((language -> Objects.equals(language.getCode(), "de")))
             .findFirst()
             .orElse(null);
     Assertions.assertNotNull(targetLanguageDe);
-    checkResult.accept(translator.translateText(exampleText.get("en"), null, targetLanguageDe));
+    checkResult.accept(client.translateText(exampleText.get("en"), null, targetLanguageDe));
 
     // Check that en and pt as target languages throw an exception
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> {
-          translator.translateText(exampleText.get("de"), null, "en");
+          client.translateText(exampleText.get("de"), null, "en");
         });
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> {
-          translator.translateText(exampleText.get("de"), null, "pt");
+          client.translateText(exampleText.get("de"), null, "pt");
         });
   }
 
   @Test
   void testInvalidLanguage() {
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     DeepLException thrown;
     thrown =
         Assertions.assertThrows(
             DeepLException.class,
             () -> {
-              translator.translateText(exampleText.get("en"), null, "XX");
+              client.translateText(exampleText.get("en"), null, "XX");
             });
     Assertions.assertTrue(thrown.getMessage().contains("target_lang"));
 
@@ -112,7 +112,7 @@ public class TranslateTextTest extends TestBase {
         Assertions.assertThrows(
             DeepLException.class,
             () -> {
-              translator.translateText(exampleText.get("en"), "XX", "de");
+              client.translateText(exampleText.get("en"), "XX", "de");
             });
     Assertions.assertTrue(thrown.getMessage().contains("source_lang"));
   }
@@ -120,13 +120,13 @@ public class TranslateTextTest extends TestBase {
   @Test
   void testTranslateWithRetries() throws DeepLException, InterruptedException {
     Assumptions.assumeTrue(isMockServer);
-    Translator translator = createTranslator(new SessionOptions().setRespondWith429(2));
+    DeepLClient client = createDeepLClient(new SessionOptions().setRespondWith429(2));
 
     long timeBefore = new Date().getTime();
     List<String> texts = new ArrayList<>();
     texts.add(exampleText.get("en"));
     texts.add(exampleText.get("ja"));
-    List<TextResult> result = translator.translateText(texts, null, "de");
+    List<TextResult> result = client.translateText(texts, null, "de");
     long timeAfter = new Date().getTime();
 
     Assertions.assertEquals(2, result.size());
@@ -139,18 +139,18 @@ public class TranslateTextTest extends TestBase {
 
   @Test
   void testFormality() throws DeepLException, InterruptedException {
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     TextResult result;
 
     result =
-        translator.translateText(
+        client.translateText(
             "How are you?", null, "de", new TextTranslationOptions().setFormality(Formality.Less));
     if (!isMockServer) {
       Assertions.assertEquals("Wie geht es dir?", result.getText());
     }
 
     result =
-        translator.translateText(
+        client.translateText(
             "How are you?",
             null,
             "de",
@@ -160,14 +160,14 @@ public class TranslateTextTest extends TestBase {
     }
 
     result =
-        translator.translateText(
+        client.translateText(
             "How are you?", null, "de", new TextTranslationOptions().setFormality(Formality.More));
     if (!isMockServer) {
       Assertions.assertEquals("Wie geht es Ihnen?", result.getText());
     }
 
     result =
-        translator.translateText(
+        client.translateText(
             "How are you?",
             null,
             "de",
@@ -177,7 +177,7 @@ public class TranslateTextTest extends TestBase {
     }
 
     result =
-        translator.translateText(
+        client.translateText(
             "How are you?",
             null,
             "de",
@@ -192,13 +192,13 @@ public class TranslateTextTest extends TestBase {
     // In German, "scharf" can mean:
     //  - spicy/hot when referring to food, or
     //  - sharp when referring to other objects such as a knife (Messer).
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     String text = "Das ist scharf!";
 
-    translator.translateText(text, null, "de");
+    client.translateText(text, null, "de");
     // Result: "That is hot!"
 
-    translator.translateText(
+    client.translateText(
         text, null, "de", new TextTranslationOptions().setContext("Das ist ein Messer."));
     // Result: "That is sharp!"
   }
@@ -207,21 +207,21 @@ public class TranslateTextTest extends TestBase {
   void testSplitSentences() throws DeepLException, InterruptedException {
     Assumptions.assumeTrue(isMockServer);
 
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     String text =
         "If the implementation is hard to explain, it's a bad idea.\nIf the implementation is easy to explain, it may be a good idea.";
 
-    translator.translateText(
+    client.translateText(
         text,
         null,
         "de",
         new TextTranslationOptions().setSentenceSplittingMode(SentenceSplittingMode.Off));
-    translator.translateText(
+    client.translateText(
         text,
         null,
         "de",
         new TextTranslationOptions().setSentenceSplittingMode(SentenceSplittingMode.All));
-    translator.translateText(
+    client.translateText(
         text,
         null,
         "de",
@@ -232,13 +232,13 @@ public class TranslateTextTest extends TestBase {
   void testPreserveFormatting() throws DeepLException, InterruptedException {
     Assumptions.assumeTrue(isMockServer);
 
-    Translator translator = createTranslator();
-    translator.translateText(
+    DeepLClient client = createDeepLClient();
+    client.translateText(
         exampleText.get("en"),
         null,
         "de",
         new TextTranslationOptions().setPreserveFormatting(true));
-    translator.translateText(
+    client.translateText(
         exampleText.get("en"),
         null,
         "de",
@@ -247,7 +247,7 @@ public class TranslateTextTest extends TestBase {
 
   @Test
   void testTagHandlingXML() throws DeepLException, InterruptedException {
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     String text =
         "<document><meta><title>A document's title</title></meta>"
             + "<content><par>"
@@ -260,7 +260,7 @@ public class TranslateTextTest extends TestBase {
             + "</content>"
             + "</document>";
     TextResult result =
-        translator.translateText(
+        client.translateText(
             text,
             null,
             "de",
@@ -279,7 +279,7 @@ public class TranslateTextTest extends TestBase {
 
   @Test
   void testTagHandlingHTML() throws DeepLException, InterruptedException {
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     String text =
         "<!DOCTYPE html>"
             + "<html>"
@@ -290,8 +290,7 @@ public class TranslateTextTest extends TestBase {
             + "</html>";
 
     TextResult result =
-        translator.translateText(
-            text, null, "de", new TextTranslationOptions().setTagHandling("html"));
+        client.translateText(text, null, "de", new TextTranslationOptions().setTagHandling("html"));
     if (!isMockServer) {
       Assertions.assertTrue(result.getText().contains("<h1>Meine erste Überschrift</h1>"));
       Assertions.assertTrue(
@@ -301,32 +300,32 @@ public class TranslateTextTest extends TestBase {
 
   @Test
   void testEmptyText() {
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> {
-          translator.translateText("", null, "de");
+          client.translateText("", null, "de");
         });
   }
 
   @Test
   void testMixedCaseLanguages() throws DeepLException, InterruptedException {
-    Translator translator = createTranslator();
+    DeepLClient client = createDeepLClient();
     TextResult result;
 
-    result = translator.translateText(exampleText.get("de"), null, "en-us");
+    result = client.translateText(exampleText.get("de"), null, "en-us");
     Assertions.assertEquals(exampleText.get("en-US"), result.getText().toLowerCase(Locale.ENGLISH));
     Assertions.assertEquals("de", result.getDetectedSourceLanguage());
 
-    result = translator.translateText(exampleText.get("de"), null, "EN-us");
+    result = client.translateText(exampleText.get("de"), null, "EN-us");
     Assertions.assertEquals(exampleText.get("en-US"), result.getText().toLowerCase(Locale.ENGLISH));
     Assertions.assertEquals("de", result.getDetectedSourceLanguage());
 
-    result = translator.translateText(exampleText.get("de"), "de", "EN-US");
+    result = client.translateText(exampleText.get("de"), "de", "EN-US");
     Assertions.assertEquals(exampleText.get("en-US"), result.getText().toLowerCase(Locale.ENGLISH));
     Assertions.assertEquals("de", result.getDetectedSourceLanguage());
 
-    result = translator.translateText(exampleText.get("de"), "dE", "EN-US");
+    result = client.translateText(exampleText.get("de"), "dE", "EN-US");
     Assertions.assertEquals(exampleText.get("en-US"), result.getText().toLowerCase(Locale.ENGLISH));
     Assertions.assertEquals("de", result.getDetectedSourceLanguage());
   }


### PR DESCRIPTION
Addressing TODO of removing createTranslator() methods in BaseTest and using createDeepLClient() instead