### PR TITLE
fix: issue#68 delete method not public

### DIFF
--- a/deepl-java/src/main/java/com/deepl/api/DeepLClient.java
+++ b/deepl-java/src/main/java/com/deepl/api/DeepLClient.java
@@ -641,7 +641,7 @@ public class DeepLClient extends Translator {
    * @throws DeepLException If any error occurs while communicating with the DeepL API, a {@link
    *     DeepLException} or a derived class will be thrown.
    */
-  void deleteMultilingualGlossary(String glossaryId) throws DeepLException, InterruptedException {
+  public void deleteMultilingualGlossary(String glossaryId) throws DeepLException, InterruptedException {
     String relativeUrl = String.format("/v3/glossaries/%s", glossaryId);
     HttpResponse response = httpClientWrapper.sendDeleteRequestWithBackoff(relativeUrl);
     this.checkResponse(response, false, true);


### PR DESCRIPTION
- this method should be public to allow deleting multilingual glossaries by only using their glossaryId.