### PR TITLE
Use Translator class instead of DeepLClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,10 @@ Be careful not to expose your key, for example when sharing source code.
 import com.deepl.api.*;
 
 class Example {
-    DeepLClient client;
-
     public Example() throws Exception {
         String authKey = "f63c02c5-f056-...";  // Replace with your key
-        translator = new Translator(authKey);
+        Translator translator = new Translator(authKey);
+
         TextResult result =
             translator.translateText("Hello, world!", null, "fr");
         System.out.println(result.getText()); // "Bonjour, le monde !"

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ class Example {
 
     public Example() throws Exception {
         String authKey = "f63c02c5-f056-...";  // Replace with your key
-        client = new DeepLClient(authKey);
+        translator = new Translator(authKey);
         TextResult result =
-                client.translateText("Hello, world!", null, "fr");
+            translator.translateText("Hello, world!", null, "fr");
         System.out.println(result.getText()); // "Bonjour, le monde !"
     }
 }


### PR DESCRIPTION
My impression is that we want to encourage people to use `Translator` if they're just doing translations. Is that right?

If not, please feel free to trash this PR :)